### PR TITLE
Add precommit hook and fix feross/standard lint errors.

### DIFF
--- a/.sublimelinterrc
+++ b/.sublimelinterrc
@@ -1,0 +1,13 @@
+{
+    "linters": {
+        "jshint": {
+            "@disable": true
+        },
+        "jsxhint": {
+            "@disable": true
+        },
+        "standard": {
+            "@disable": false
+        }
+    }
+}

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: node_js
+node_js:
+  - "0.10"
+  - "0.12"
+
+# See http://docs.travis-ci.com/user/workers/container-based-infrastructure/
+sudo: false

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -15,7 +15,7 @@ var reactify = require('reactify')
 var open = require('gulp-open')
 var del = require('del')
 var NwBuilder = require('node-webkit-builder')
-var ipfs_static = require('ipfs-node-server-static')('localhost', 5001, {api: true});
+var ipfs_static = require('ipfs-node-server-static')('localhost', 5001, {api: true})
 
 var paths = {
   build: 'build/',
@@ -27,13 +27,13 @@ var paths = {
   html: ['html/**/*.html'],
 }
 
-var server_port = process.env.PORT || 8000;
+var server_port = process.env.PORT || 8000
 
-gulp.task('clean', function(cb) {
+gulp.task('clean', function (cb) {
   del([paths.build], cb)
 })
 
-gulp.task('js', function() {
+gulp.task('js', function () {
   return browserify(paths.main)
     .transform(reactify)
     .bundle()
@@ -45,78 +45,76 @@ gulp.task('js', function() {
     // .pipe(sourcemaps.write())
     .pipe(gulp.dest('build/static'))
 })
-
-gulp.task('css', function() {
+gulp.task('css', function () {
   return gulp.src(paths.css)
     .pipe(sourcemaps.init())
-      .pipe(less())
-      .pipe(cssmin())
-      .pipe(concat('bundle.min.css'))
+    .pipe(less())
+    .pipe(cssmin())
+    .pipe(concat('bundle.min.css'))
     .pipe(sourcemaps.write())
     .pipe(gulp.dest('build/static'))
 })
-
-gulp.task('img', function() {
+gulp.task('img', function () {
   return gulp.src(paths.img)
-    //.pipe(imagemin({optimizationLevel: 5}))
+    // .pipe(imagemin({optimizationLevel: 5}))
     .pipe(gulp.dest('build/static'))
     .pipe(connect.reload())
 })
-
-gulp.task('static', function() {
+gulp.task('static', function () {
   return gulp.src(paths.static)
     .pipe(gulp.dest('build/static'))
     .pipe(connect.reload())
 })
-
-gulp.task('html', function() {
+gulp.task('html', function () {
   return gulp.src(paths.html)
     .pipe(gulp.dest('build/'))
 })
-
-gulp.task('compile', ['js', 'css', 'img', 'static', 'html'])
-
-gulp.task('watch', function() {
+gulp.task('compile', [
+  'js',
+  'css',
+  'img',
+  'static',
+  'html'
+])
+gulp.task('watch', function () {
   gulp.watch(paths.js, ['js'])
   gulp.watch(paths.css, ['css'])
   gulp.watch(paths.img, ['img'])
   gulp.watch(paths.html, ['html'])
 })
-
-gulp.task('server', function() {
+gulp.task('server', function () {
   connect.server({
     root: 'build',
     fallback: 'build/index.html',
     port: server_port,
     livereload: true,
-    middleware: function(connect, opts) {
+    middleware: function (connect, opts) {
       return [ipfs_static]
     }
   })
 })
-
-gulp.task('build', ['compile'], function() {
+gulp.task('build', ['compile'], function () {
   var stream = gulp.src('nw-package.json')
     .pipe(rename('package.json'))
     .pipe(gulp.dest('build'))
 
-  stream.on('end', function() {
+  stream.on('end', function () {
     var nw = new NwBuilder({
       files: ['build/**', '!build/ipfs-webui/**'],
       platforms: ['osx', 'win', 'linux32', 'linux64']
     })
-    nw.build(function(err) {
+    nw.build(function (err) {
       if(err) console.error(err)
     })
   })
 })
 
-gulp.task('open', function(){
+gulp.task('open', function () {
   var options = {
     url: 'http://localhost:' + server_port
-  };
+  }
   gulp.src('./html/index.html')
-  .pipe(open('', options));
-});
+    .pipe(open('', options))
+})
 
 gulp.task('default', ['watch', 'compile', 'server', 'open'])

--- a/js/app.jsx
+++ b/js/app.jsx
@@ -30,7 +30,7 @@ module.exports = (
     <Route name="routing" handler={RoutingPage} />
     <Route name="config" handler={ConfigPage} />
     <Route name="logs" handler={LogPage} />
-    <NotFoundRoute handler={HomePage} />
+    <NotFoundRoute handler={NotFoundPage} />
     <Redirect from="/index.html" to="home" />
   </Route>
 )

--- a/js/getlocation.js
+++ b/js/getlocation.js
@@ -1,25 +1,28 @@
-function isLocal(address) {
+'use strict'
+
+function isLocal (address) {
   var split = address.split('.')
-  if(split[0] === '10') return true
-  if(split[0] === '127') return true
-  if(split[0] === '192' && split[1] === '168') return true
-  if(split[0] === '172' && +split[1] >= 16 && +split[1] <= 31) return true
+  if (split[0] === '10') return true
+  if (split[0] === '127') return true
+  if (split[0] === '192' && split[1] === '168') return true
+  if (split[0] === '172' && +split[1] >= 16 && +split[1] <= 31) return true
   return false
 }
 
-var getLocation = module.exports = function(multiaddrs, cb) {
-  if(multiaddrs.length === 0) return cb(null, null)
+var getLocation = module.exports = function (multiaddrs, cb) {
+  if (multiaddrs.length === 0) return cb(null, null)
   var address = multiaddrs[0].split('/')[2]
-  if(isLocal(address)) return getLocation(multiaddrs.slice(1), cb)
+  if (isLocal(address)) return getLocation(multiaddrs.slice(1), cb)
 
-  $.get('http://freegeoip.net/json/' + address, function(res) {
-    if(!res.country_name && multiaddrs.length > 1)
-        return getLocation(multiaddrs.slice(1), cb)
-    
+  window.$.get('http://freegeoip.net/json/' + address, function (res) {
+    if (!res.country_name && multiaddrs.length > 1) {
+      return getLocation(multiaddrs.slice(1), cb)
+    }
+
     var location = 'Earth'
-    if(res.country_name) location = res.country_name + ', ' + location
-    if(res.region_code) location = res.region_code + ', ' + location
-    if(res.city) location = res.city + ', ' + location
+    if (res.country_name) location = res.country_name + ', ' + location
+    if (res.region_code) location = res.region_code + ', ' + location
+    if (res.city) location = res.city + ', ' + location
 
     res.formatted = location
     cb(null, res)

--- a/js/linkhandler.js
+++ b/js/linkhandler.js
@@ -1,26 +1,24 @@
-var Router = require('react-router')
+'use strict'
+// var Router = require('react-router')
+var $ = window.$
 
-function linkHandler()  {
-
+function linkHandler () {
   var external = /^(https?:)?\/\//i
-  var static = /^\/static\//i
+  var staticLink = /^\/static\//i
 
-  $(document.body).on('click', 'a', function(event) {
-
+  $(document.body).on('click', 'a', function (event) {
     var href = $(this).attr('href')
     console.log(href)
 
     // pass through if external or static
-    if (external.test(href) || static.test(href))
-      return
+    if (external.test(href) || staticLink.test(href)) return
 
     // bail if already defaultPrevented
-    if (event.defaultPrevented)
-      return
+    if (event.defaultPrevented) return
 
     event.preventDefault()
     return false
-  });
+  })
 }
 
 module.exports = linkHandler

--- a/js/main.jsx
+++ b/js/main.jsx
@@ -1,18 +1,21 @@
-'use strict';
-var React = require('react');
-var Router = require('react-router');
-var routes = require('./app.jsx');
-var linkHandler = require('./linkhandler.js');
+'use strict'
+var React = require('react')
+var Router = require('react-router')
+var routes = require('./app.jsx')
+var $ = window.$
+var ZeroClipboard = window.ZeroClipboard
+
+// var linkHandler = require('./linkhandler.js')
 if (process.env.NODE_ENV !== 'production') {
-  window.uiDebug = require("debug");
+  window.uiDebug = require('debug')
 }
 
 // jquery entry point.
-$(document).ready(function() {
-  var appEl = document.getElementById('webui-app');
-  Router.run(routes, function(Handler) {
-    React.render(<Handler />, appEl);
-  });
+$(document).ready(function () {
+  var appEl = document.getElementById('webui-app')
+  Router.run(routes, function (Handler) {
+    React.render(<Handler />, appEl)
+  })
 
-  ZeroClipboard.config({ swfPath: './static/js/ZeroClipboard.swf' });
-});
+  ZeroClipboard.config({ swfPath: './static/js/ZeroClipboard.swf' })
+})

--- a/js/pages/bitswap.jsx
+++ b/js/pages/bitswap.jsx
@@ -1,14 +1,13 @@
 var React = require('react')
-var Router = require('react-router')
 var FileList = require('../views/filelist.jsx')
 
 module.exports = React.createClass({
-  getInitialState: function() {
+  getInitialState: function () {
     var t = this
 
-    var update = function() {
-      t.props.ipfs.send('bitswap/wantlist', null, null, null, function(err, res) {
-        if(err) return console.error(err)
+    var update = function () {
+      t.props.ipfs.send('bitswap/wantlist', null, null, null, function (err, res) {
+        if (err) return console.error(err)
         t.setState({ wantlist: res })
       })
     }
@@ -21,11 +20,11 @@ module.exports = React.createClass({
     }
   },
 
-  componentWillUnmount: function() {
+  componentWillUnmount: function () {
     clearInterval(this.props.pollInterval)
   },
 
-  render: function() {
+  render: function () {
     var wantlist = this.state.wantlist
 
     return (

--- a/js/pages/config.jsx
+++ b/js/pages/config.jsx
@@ -1,24 +1,21 @@
 var React = require('react')
-var Router = require('react-router')
-var Nav = require('../views/nav.jsx')
 var Config = require('../views/config.jsx')
 
-module.exports = React.createClass({
-  getInitialState: function() {
+var Config = React.createClass({
+  getInitialState: function () {
     var t = this
-    t.props.ipfs.config.show(function(err, config) {
+    t.props.ipfs.config.show(function (err, config) {
       console.log(err, config)
-      if(!err) t.setState({ config: config })
+      if (!err) t.setState({ config: config })
     })
 
     return { config: null }
   },
 
-  render: function() {
-    var config = this.state.config ? Config({
-      config: this.state.config,
-      ipfs: this.props.ipfs
-    }) : null
+  render: function () {
+    var config = this.state.config ?
+      <Config config={this.state.config} ipfs={this.props.ipfs} />
+      : null
 
     return (
       <div className="row">
@@ -29,3 +26,5 @@ module.exports = React.createClass({
     )
   }
 })
+
+module.exports = Config

--- a/js/pages/connections.jsx
+++ b/js/pages/connections.jsx
@@ -1,79 +1,76 @@
-'use strict';
+'use strict'
 var React = require('react/addons')
 var PureRenderMixin = React.addons.PureRenderMixin
 var LocalStorageMixin = require('react-localstorage')
-var Nav = require('../views/nav.jsx')
 var ConnectionList = require('../views/connectionlist.jsx')
-var SwarmVis = require('../views/swarmvis.jsx')
 var getLocation = require('../getlocation.js')
-var LocalStorage = require('../utils/localStorage')
 var debug = require('debug')('ipfs:pages:connections')
 var _ = require('lodash')
 
 var Connections = React.createClass({
-  getInitialState: function() {
+  getInitialState: function () {
     return {
       peers: [],
       locations: {},
       nonce: 0
-    };
+    }
   },
 
-  componentDidMount: function() {
-    var t = this;
+  componentDidMount: function () {
+    var t = this
 
-    var getPeers = function() {
-      t.props.ipfs.swarm.peers(function(err, res) {
-        if(err) return console.error(err);
+    var getPeers = function () {
+      t.props.ipfs.swarm.peers(function (err, res) {
+        if (err) return console.error(err)
 
-        var peers = res.Strings.map(function(peer) {
-          var slashIndex = peer.lastIndexOf('/');
+        var peers = res.Strings.map(function (peer) {
+          var slashIndex = peer.lastIndexOf('/')
           return {
             Address: peer.substr(0, slashIndex),
-            ID: peer.substr(slashIndex+1)
-          };
-        });
+            ID: peer.substr(slashIndex + 1)
+          }
+        })
 
-        peers = peers.sort(function(a, b) {
-          return a.ID > b.ID ? 1 : -1;
-        });
-        peers.map(function(peer) {
-          peer.ipfs = t.props.ipfs;
-          peer.location = { formatted: '' };
+        peers = peers.sort(function (a, b) {
+          return a.ID > b.ID ? 1 : -1
+        })
+        peers.map(function (peer) {
+          peer.ipfs = t.props.ipfs
+          peer.location = { formatted: '' }
 
-          var location = t.state.locations[peer.ID];
-          if(!location) {
-            t.state.locations[peer.ID] = {};
-            t.props.ipfs.id(peer.ID, function(err, id) {
-              if(err) return console.error(err);
+          var location = t.state.locations[peer.ID]
+          if (!location) {
+            t.state.locations[peer.ID] = {}
+            t.props.ipfs.id(peer.ID, function (err, id) {
+              if (err) return console.error(err)
 
-              getLocation(id.Addresses, function(err, res) {
-                if(err) return console.error(err);
+              getLocation(id.Addresses, function (err, res) {
+                if (err) return console.error(err)
 
-                res = res || {};
-                peer.location = res;
-                t.state.locations[peer.ID] = res;
+                res = res || {}
+                peer.location = res
+                t.state.locations[peer.ID] = res
                 t.setState({
                   peers: peers,
                   locations: t.state.locations,
                   nonce: t.state.nonce++
-                });
-              });
-            });
+                })
+              })
+            })
           }
-        });
-      });
-    };
+        })
+      })
+    }
 
-    t.pollInterval = setInterval(getPeers, 1000);
-    getPeers();
+    t.pollInterval = setInterval(getPeers, 1000)
+    getPeers()
   },
 
-  componentWillUnmount: function() {
-    clearInterval(this.pollInterval);
+  componentWillUnmount: function () {
+    clearInterval(this.pollInterval)
   },
 
-  render: function() {
+  render: function () {
     return (
       <div className="row">
         <div className="col-sm-6 globe-column">
@@ -86,88 +83,87 @@ var Connections = React.createClass({
           </div>
         </div>
       </div>
-    );
+    )
   }
-});
+})
 
-var lsKey = 'globeTheme';
 var Globe = React.createClass({
 
   mixins: [PureRenderMixin, LocalStorageMixin],
 
-  getInitialState: function() {
+  getInitialState: function () {
     return {
       theme: 'light'
-    };
+    }
   },
 
-  componentDidMount: function() {
-    this.createGlobe();
+  componentDidMount: function () {
+    this.createGlobe()
   },
 
-  componentWillUnmount: function() {
-    this.globe && this.globe.dispose();
+  componentWillUnmount: function () {
+    this.globe && this.globe.dispose()
   },
 
-  componentDidUpdate: function(prevProps, prevState) {
+  componentDidUpdate: function (prevProps, prevState) {
     if (prevState.theme !== this.state.theme) {
-      debug('disposing globe');
-      this.globe && this.globe.dispose();
-      this.createGlobe();
+      debug('disposing globe')
+      this.globe && this.globe.dispose()
+      this.createGlobe()
     }
 
-    this.addPoints(this.state.globe);
+    this.addPoints(this.state.globe)
   },
 
-  addPoints: function() {
-    var data = this.parsePeers();
-    if (!this.globe || !data.length) return;
+  addPoints: function () {
+    var data = this.parsePeers()
+    if (!this.globe || !data.length) return
     // TODO find difference between old points and new points
     // and only add the new ones. THREE might be doing this internally.
-    debug('adding %d points, %j', data.length, data);
-    this.globe.addData(data, { format: 'magnitude' });
-    this.globe.createPoints();
+    debug('adding %d points, %j', data.length, data)
+    this.globe.addData(data, { format: 'magnitude' })
+    this.globe.createPoints()
   },
 
-  createGlobe: function() {
-    var slash = window.location.pathname.slice(-1) === '/' ? '' : '/';
-    var texturePath = window.location.pathname + slash + 'static/img/';
-    if (this.state.theme === 'dark') texturePath += 'dark-';
+  createGlobe: function () {
+    var slash = window.location.pathname.slice(-1) === '/' ? '' : '/'
+    var texturePath = window.location.pathname + slash + 'static/img/'
+    if (this.state.theme === 'dark') texturePath += 'dark-'
 
-    debug('mounting globe');
+    debug('mounting globe')
     this.globe = new window.DAT.Globe(this.refs.globe.getDOMNode(), {
       imgDir: texturePath
-    });
-    this.globe.animate();
+    })
+    this.globe.animate()
   },
 
-  parsePeers: function(peers) {
-    var data = {};
-    _.forEach(this.props.peers, function(peer, i) {
-      if (!(peer.location && peer.location.latitude && peer.location.longitude)) return;
-      var key = peer.location.latitude + '|' + peer.location.longitude;
-      if (!data[key]) data[key] = 0;
-      data[key] = [peer.location.latitude, peer.location.longitude, Math.min(10, data[key] + 0.1)];
-    });
+  parsePeers: function (peers) {
+    var data = {}
+    _.forEach(this.props.peers, function (peer, i) {
+      if (!(peer.location && peer.location.latitude && peer.location.longitude)) return
+      var key = peer.location.latitude + '|' + peer.location.longitude
+      if (!data[key]) data[key] = 0
+      data[key] = [peer.location.latitude, peer.location.longitude, Math.min(10, data[key] + 0.1)]
+    })
 
-    return _.flatten(_.values(data));
+    return _.flatten(_.values(data))
   },
 
-  toggleTheme: function() {
-    var theme = this.state.theme === 'dark' ? 'light' : 'dark';
-    this.setState({theme: theme});
+  toggleTheme: function () {
+    var theme = this.state.theme === 'dark' ? 'light' : 'dark'
+    this.setState({theme: theme})
   },
 
-  render: function() {
+  render: function () {
     return (
       <div className="globe-container">
-        <div ref="globe" style={{width:'100%', 'height': '600px'}}></div>
+        <div ref="globe" style={{width: '100%', height: '600px'}}></div>
         <div className="theme-toggle" onClick={this.toggleTheme}>
           <i className="fa fa-exchange" />
         </div>
       </div>
-    );
+    )
   }
-});
+})
 
-module.exports = Connections;
+module.exports = Connections

--- a/js/pages/home.jsx
+++ b/js/pages/home.jsx
@@ -1,17 +1,12 @@
 var React = require('react')
-var Nav = require('../views/nav.jsx')
-var NodeProps = require('../views/nodeprops.jsx')
-var Table = require('../views/table.jsx')
-var TabbedArea = require('react-bootstrap/lib/TabbedArea')
-var TabPane = require('react-bootstrap/lib/TabPane')
 var Peer = require('../views/peer.jsx')
 var getLocation = require('../getlocation.js')
 
-module.exports = React.createClass({
-  getInitialState: function() {
+var Home = React.createClass({
+  getInitialState: function () {
     var t = this
-    t.props.ipfs.id(function(err, peer) {
-      if(err || !peer) return console.error(err)
+    t.props.ipfs.id(function (err, peer) {
+      if (err || !peer) return console.error(err)
       t.setState({
         node: {
           peer: peer,
@@ -19,8 +14,8 @@ module.exports = React.createClass({
         }
       })
 
-      getLocation(peer.Addresses, function(err, location) {
-        if(err || !location) return console.error(err)
+      getLocation(peer.Addresses, function (err, location) {
+        if (err || !location) return console.error(err)
         t.setState({
           node: {
             peer: peer,
@@ -30,9 +25,9 @@ module.exports = React.createClass({
       })
     })
 
-    t.props.ipfs.config.get('Gateway.Enabled', function(err, enabled) {
-      if(err) return console.error(err);
-      t.setState({ GatewayEnabled: enabled.Value });
+    t.props.ipfs.config.get('Gateway.Enabled', function (err, enabled) {
+      if (err) return console.error(err)
+      t.setState({ GatewayEnabled: enabled.Value })
     })
 
     return {
@@ -51,42 +46,45 @@ module.exports = React.createClass({
     }
   },
 
-  onGatewayChange: function(e) {
-    var t = this;
-    var enabled = !t.state.GatewayEnabled;
-    var api = enabled ? t.props.ipfs.gateway.enable : t.props.ipfs.gateway.disable;
-    api(function(err) {
-      if(err) return console.error(err);
-      t.setState({ GatewayEnabled: enabled });
-    });
+  onGatewayChange: function (e) {
+    var t = this
+    var enabled = !t.state.GatewayEnabled
+    var api = enabled ? t.props.ipfs.gateway.enable : t.props.ipfs.gateway.disable
+    api(function (err) {
+      if (err) return console.error(err)
+      t.setState({ GatewayEnabled: enabled })
+    })
   },
 
-  render: function() {
-    var gatewayEnabled = this.state.GatewayEnabled;
-    var gatewayLink;
-    if(gatewayEnabled)
+  render: function () {
+    var gatewayEnabled = this.state.GatewayEnabled
+    var gatewayLink
+    if (gatewayEnabled) {
       gatewayLink = <a href={this.state.GatewayUrl}>Go to gateway</a>
+    }
 
     return (
-  <div className="row">
-    <div className="col-sm-10 col-sm-offset-1">
+      <div className="row">
+        <div className="col-sm-10 col-sm-offset-1">
 
-      <h3>Node Info</h3>
-      <Peer {...this.state.node} />
+          <h3>Node Info</h3>
+          <Peer {...this.state.node} />
 
-      <div className="well hidden">
-        <h4>HTTP Gateway</h4>
-        <div className="checkbox">
-          <label>
-            <input type="checkbox" className="gateway-toggle" checked={gatewayEnabled} onChange={this.onGatewayChange}/>
-            <strong>Enabled</strong>
-          </label>
+          <div className="well hidden">
+            <h4>HTTP Gateway</h4>
+            <div className="checkbox">
+              <label>
+                <input type="checkbox" className="gateway-toggle" checked={gatewayEnabled} onChange={this.onGatewayChange}/>
+                <strong>Enabled</strong>
+              </label>
+            </div>
+            {gatewayLink}
+          </div>
+
         </div>
-        {gatewayLink}
       </div>
-
-    </div>
-  </div>
     )
   }
 })
+
+module.exports = Home

--- a/js/pages/logs.jsx
+++ b/js/pages/logs.jsx
@@ -1,28 +1,29 @@
 var React = require('react')
+var $ = window.$
 
 var MAXSIZE = 1000
 
-module.exports = React.createClass({
-  getInitialState: function() {
+var Logs = React.createClass({
+  getInitialState: function () {
     var t = this
-    var req = this.props.ipfs.log.tail(function(err, stream) {
-      if(err) return console.error(err)
+    var req = this.props.ipfs.log.tail(function (err, stream) {
+      if (err) return console.error(err)
 
       var container = $(t.getDOMNode()).find('.textarea-panel').get(0)
 
-      stream.on('data', function(chunk) {
+      stream.on('data', function (chunk) {
         var parts = chunk.toString().split('}')
         var buf = ''
 
-        parts.forEach(function(part) {
-          buf += part+'}'
+        parts.forEach(function (part) {
+          buf += part + '}'
           try {
             var obj = JSON.parse(buf)
             t.state.log.push(obj)
-            if(t.state.log.length > MAXSIZE) t.state.log.shift()
+            if (t.state.log.length > MAXSIZE) t.state.log.shift()
             t.setState({ log: t.state.log, nonce: t.state.nonce + 1 })
-            if(t.state.tailing) container.scrollTop = container.scrollHeight
-          } catch(e){}
+            if (t.state.tailing) container.scrollTop = container.scrollHeight
+          } catch(e) {}
         })
       })
     })
@@ -35,27 +36,28 @@ module.exports = React.createClass({
     }
   },
 
-  componentWillUnmount: function() {
+  componentWillUnmount: function () {
     this.state.request.destroy()
   },
 
-  clear: function() {
+  clear: function () {
     this.setState({ log: [] })
   },
 
-  toggleTail: function() {
+  toggleTail: function () {
     this.setState({ tailing: !this.state.tailing })
   },
 
-  getUrl: function() {
+  getUrl: function () {
     return 'http://' + this.props.host + '/api/v0/log/tail?enc=text'
   },
 
-  render: function() {
+  render: function () {
     var buttons = (
       <div className="buttons">
         <button className="btn btn-second" onClick={this.clear}>Clear</button>
-        <button className={"btn btn-second "+(this.state.tailing ? "active" : "")} data-toggle="button" aria-pressed={this.state.tailing} onClick={this.toggleTail}>Tail</button>
+        <button className={'btn btn-second ' + (this.state.tailing ? 'active' : '')}
+          data-toggle="button" aria-pressed={this.state.tailing} onClick={this.toggleTail}>Tail</button>
       </div>
     )
 
@@ -67,7 +69,7 @@ module.exports = React.createClass({
         <br/>
 
         <div className="textarea-panel panel panel-default padded" style={{height: '600px'}}>
-          {this.state.log.map(function(event) {
+          {this.state.log.map(function (event) {
             return <pre key={event.time}>{JSON.stringify(event, null, '  ')}</pre>
           })}
         </div>
@@ -79,3 +81,5 @@ module.exports = React.createClass({
     )
   }
 })
+
+module.exports = Logs

--- a/js/pages/notfound.jsx
+++ b/js/pages/notfound.jsx
@@ -1,18 +1,19 @@
 var React = require('react')
-var Nav = require('../views/nav.jsx')
 
-module.exports = React.createClass({
-  render: function() {
+var NotFound = React.createClass({
+  render: function () {
     return (
-  <div className="row">
-    <div className="col-sm-10 col-sm-offset-1">
+      <div className="row">
+        <div className="col-sm-10 col-sm-offset-1">
 
-      <h1>404 - Not Found</h1>
+          <h1>404 - Not Found</h1>
 
-      <p><a href="/">Go to console home</a></p>
+          <p><a href="/">Go to console home</a></p>
 
-    </div>
-  </div>
+        </div>
+      </div>
     )
   }
 })
+
+module.exports = NotFound

--- a/js/pages/objects.jsx
+++ b/js/pages/objects.jsx
@@ -1,57 +1,57 @@
 var React = require('react')
 var Router = require('react-router')
-var Nav = require('../views/nav.jsx')
+var $ = window.$
 var ObjectView = require('../views/object.jsx')
 
 module.exports = React.createClass({
   mixins: [ Router.State ],
 
-  componentDidMount: function() {
+  componentDidMount: function () {
     window.addEventListener('hashchange', this.handleHashChange)
   },
 
-  componentWillUnmount: function() {
+  componentWillUnmount: function () {
     window.removeEventListener('hashchange', this.handleHashChange)
   },
 
-  getInitialState: function() {
-    var hash = window.location.hash.substr('/objects'.length+1)
+  getInitialState: function () {
+    var hash = window.location.hash.substr('/objects'.length + 1)
     hash = (hash || '').replace(/[\\]/g, '/')
-    if(hash.split('/')[0].length === 0) hash = hash.slice(1)
-    if(hash) this.getObject(hash)
+    if (hash.split('/')[0].length === 0) hash = hash.slice(1)
+    if (hash) this.getObject(hash)
 
     return { object: null, hash: hash, hashInput: hash }
   },
 
-  handleHashChange: function() {
+  handleHashChange: function () {
     console.log('handleHashChange: ' + this.state.hash + ' ' + window.location.hash)
     var hash = window.location.hash
-    if(!/^#\/objects/.test(hash)) return
-    hash = hash.substring('#/objects'.length+1).replace(/\\/g, '/')
+    if (!/^#\/objects/.test(hash)) return
+    hash = hash.substring('#/objects'.length + 1).replace(/\\/g, '/')
     this.setState({ hash: hash, hashInput: hash })
     this.getObject(hash)
   },
 
-  handleBack: function(e) {
+  handleBack: function (e) {
     var hash = this.state.hash
     var slashIndex = hash.lastIndexOf('/')
-    if(slashIndex === -1) return
+    if (slashIndex === -1) return
     hash = hash.substr(0, slashIndex)
     this.setState({ hash: hash })
     this.getObject(hash)
   },
 
-  getObject: function(path) {
+  getObject: function (path) {
     console.log('getObject:', path)
 
-    if(path[0] === '/' && !/^\/ip[fn]s\//.test(path)) {
+    if (path[0] === '/' && !/^\/ip[fn]s\//.test(path)) {
       path = path.slice(1)
       this.setState({ hash: path })
     }
 
     var t = this
-    t.props.ipfs.object.get(path, function(err, res) {
-      if(err) return console.error(err)
+    t.props.ipfs.object.get(path, function (err, res) {
+      if (err) return console.error(err)
 
       path = path.replace(/[\/]/g, '\\')
       var hash = '#/objects/' + path
@@ -60,22 +60,22 @@ module.exports = React.createClass({
     })
   },
 
-  updateHash: function(e) {
+  updateHash: function (e) {
     var hash = $(e.target).val().trim()
     this.setState({ hashInput: hash })
   },
 
-  update: function(e) {
-    if(e.which && e.which !== 13) return
+  update: function (e) {
+    if (e.which && e.which !== 13) return
     this.setState({ hash: this.state.hashInput })
-    if(this.state.hashInput) this.getObject(this.state.hashInput)
+    if (this.state.hashInput) this.getObject(this.state.hashInput)
   },
 
-  render: function() {
+  render: function () {
     var object = this.state.object ?
       <ObjectView object={this.state.object} handleBack={this.handleBack}
         path={this.state.hash} gateway={this.props.gateway} />
-      : null;
+      : null
 
     return (
       <div className="row">

--- a/js/pages/routing.jsx
+++ b/js/pages/routing.jsx
@@ -1,35 +1,34 @@
 var React = require('react')
-var Router = require('react-router')
 var DHTGraph = require('../views/dhtgraph.jsx')
 
 var base58Chars = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz'
 var base58Index = {}
-for(var i = 0; i < base58Chars.length; i++) {
+for (var i = 0; i < base58Chars.length; i++) {
   base58Index[base58Chars[i]] = i / 58
 }
 
-function idToAngle(id) {
+function idToAngle (id) {
   var sub = id.substr(2, 4)
   var angle = 0
-  for(var i = 0; i < sub.length; i++) {
+  for (var i = 0; i < sub.length; i++) {
     angle += base58Index[sub[i]] * (1 / Math.pow(58, i))
   }
   return angle * Math.PI * 2
 }
 
-module.exports = React.createClass({
-  getInitialState: function() {
+var Routing = React.createClass({
+  getInitialState: function () {
     var t = this
 
-    t.props.ipfs.id(function(err, id) {
-      if(err) return console.error(err)
+    t.props.ipfs.id(function (err, id) {
+      if (err) return console.error(err)
 
-      t.props.ipfs.swarm.peers(function(err, res) {
-        if(err) return console.error(err)
+      t.props.ipfs.swarm.peers(function (err, res) {
+        if (err) return console.error(err)
 
         var peers = res.Peers || []
         peers.push(id)
-        peers = peers.map(function(peer) {
+        peers = peers.map(function (peer) {
           return {
             pos: idToAngle(peer.ID),
             id: peer.ID
@@ -46,7 +45,7 @@ module.exports = React.createClass({
     }
   },
 
-  render: function() {
+  render: function () {
     return (
       <div className="row">
         <div className="col-sm-10 col-sm-offset-1">
@@ -56,3 +55,5 @@ module.exports = React.createClass({
     )
   }
 })
+
+module.exports = Routing

--- a/js/utils/localStorage.js
+++ b/js/utils/localStorage.js
@@ -1,42 +1,41 @@
-'use strict';
-var _ = require('lodash');
+'use strict'
+var _ = require('lodash')
 
 // Utility to make interacting with localstorage less painful.
-var ls = process.browser && window.localStorage;
+var ls = process.browser && window.localStorage
 
 // LS API is obnoxious this way
 var translations = {
   get: 'getItem',
   set: 'setItem',
   remove: 'removeItem'
-};
-var operations = ['getItem', 'setItem', 'clear', 'removeItem'].concat(_.keys(translations));
+}
+var operations = ['getItem', 'setItem', 'clear', 'removeItem'].concat(_.keys(translations))
 
-_.each(operations, function(op) {
-  var opName = translations[op] || op;
-  module.exports[op] = doOperation.bind(null, opName);
-});
+_.each(operations, function (op) {
+  var opName = translations[op] || op
+  module.exports[op] = doOperation.bind(null, opName)
+})
 
-function doOperation(op) {
-  if (!ls) return;
-  var args = _.toArray(arguments).slice(1);
+function doOperation (op) {
+  if (!ls) return
+  var args = _.toArray(arguments).slice(1)
   // Allow setting objects directly
   if (op === 'setItem' && args[1] !== 'string') {
-    args[1] = JSON.stringify(args[1]);
+    args[1] = JSON.stringify(args[1])
   }
 
   try {
-    var result = ls[op].apply(ls, args);
+    var result = ls[op].apply(ls, args)
     // If getting, attempt to parse
     if (op === 'getItem') {
       try {
-        result = JSON.parse(result);
+        result = JSON.parse(result)
       } catch(e) {}
     }
 
-    return result;
+    return result
   } catch(e) {
-    console.warn('LocalStorage error: ' + e.message);
+    console.warn('LocalStorage error: ' + e.message)
   }
 }
-

--- a/js/views/config.jsx
+++ b/js/views/config.jsx
@@ -1,9 +1,8 @@
 var React = require('react')
-var addr = require('./typography.jsx').addr
-var Editable = require('./editable.jsx')
+var $ = window.$
 
 module.exports = React.createClass({
-  getInitialState: function() {
+  getInitialState: function () {
     return {
       body: JSON.stringify(this.props.config, null, '\t'),
       error: null,
@@ -12,24 +11,24 @@ module.exports = React.createClass({
     }
   },
 
-  reset: function() {
+  reset: function () {
     this.setState({
       body: JSON.stringify(this.props.config, null, '\t'),
       error: null
     })
   },
 
-  componentDidMount: function() {
+  componentDidMount: function () {
     this.updateHeight()
   },
 
-  updateHeight: function() {
+  updateHeight: function () {
     var el = $(this.getDOMNode()).find('textarea')
     el.height('1px')
     el.height(el.get(0).scrollHeight)
   },
 
-  handleChange: function(e) {
+  handleChange: function (e) {
     var text = e.target.value
     var error
 
@@ -47,7 +46,7 @@ module.exports = React.createClass({
     })
   },
 
-  save: function(e) {
+  save: function (e) {
     var t = this
     t.setState({
       body: t.state.body,
@@ -56,12 +55,13 @@ module.exports = React.createClass({
 
     console.log(t.state.body)
 
-    t.props.ipfs.config.replace(new Buffer(t.state.body), function(err) {
+    t.props.ipfs.config.replace(new Buffer(t.state.body), function (err) {
       var newState = { saving: false }
-      if(err) newState.error = err.message
-      else {
+      if (err) {
+        newState.error = err.message
+      } else {
         newState.saved = true
-        setTimeout(function() {
+        setTimeout(function () {
           t.setState({ saved: false })
         }, 4000)
       }
@@ -69,10 +69,11 @@ module.exports = React.createClass({
     })
   },
 
-  render: function() {
+  render: function () {
     var buttonClass = 'btn btn-success pull-right'
-    if(this.state.error || this.state.saving || this.state.saved)
+    if (this.state.error || this.state.saving || this.state.saved) {
       buttonClass += ' disabled'
+    }
 
     var buttons = (
       <div className="controls">
@@ -89,7 +90,7 @@ module.exports = React.createClass({
     )
 
     var error = null
-    if(this.state.error) {
+    if (this.state.error) {
       error = (
         <div>
           <span className="text-danger pull-left">

--- a/js/views/connectionlist.jsx
+++ b/js/views/connectionlist.jsx
@@ -1,20 +1,17 @@
 var React = require('react')
-var Table = require('react-bootstrap/lib/Table')
-var addr = require('./typography.jsx').addr
-
 var Peer = require('./peer.jsx')
 
 var Connection = React.createClass({
-  getInitialState: function() {
+  getInitialState: function () {
     return { open: false }
   },
 
-  handleClick: function(e) {
-    if(this.state.open) return this.setState({ open: false })
+  handleClick: function (e) {
+    if (this.state.open) return this.setState({ open: false })
 
     var t = this
-    t.props.ipfs.id(t.props.ID, function(err, peer) {
-      if(err) return console.error(err)
+    t.props.ipfs.id(t.props.ID, function (err, peer) {
+      if (err) return console.error(err)
 
       t.setState({
         open: true,
@@ -23,17 +20,17 @@ var Connection = React.createClass({
     })
   },
 
-  render: function() {
+  render: function () {
     var peer = this.state.open ?
       <Peer
         peer={this.state.peer}
         location={this.props.location}
         bytesRead={this.props.BytesRead}
         bytesWritten={this.props.BytesWritten} />
-      : null;
+      : null
 
     var className = 'webui-connection list-group-item'
-    if(this.state.open) className += ' active'
+    if (this.state.open) className += ' active'
 
     return (
       <li className={className}>
@@ -50,12 +47,12 @@ var Connection = React.createClass({
 })
 
 var ConnectionList = React.createClass({
-  render: function() {
+  render: function () {
     var peers = this.props.peers || []
 
     return (
       <ul className="list-group">
-        {peers.map(function(peer, i) {
+        {peers.map(function (peer, i) {
           return <Connection {...peer} key={i} />
         })}
       </ul>
@@ -63,4 +60,4 @@ var ConnectionList = React.createClass({
   }
 })
 
-module.exports = ConnectionList;
+module.exports = ConnectionList

--- a/js/views/copier.jsx
+++ b/js/views/copier.jsx
@@ -1,38 +1,42 @@
 var React = require('react')
+var $ = window.$
+var ZeroClipboard = window.ZeroClipboard
 
 module.exports = React.createClass({
-  getInitialState: function() {
+  getInitialState: function () {
     return { clicked: false }
   },
 
-  componentDidMount: function() {
-    new ZeroClipboard($(this.getDOMNode()))
+  componentDidMount: function () {
+    new ZeroClipboard($(this.getDOMNode())) // eslint-disable-line
     $(this.getDOMNode()).tooltip()
   },
 
-  updateTooltip: function(clicked) {
+  updateTooltip: function (clicked) {
     var el = $(this.getDOMNode())
-    var tooltip = !clicked ? (this.props.tooltip||'Copy to clipboard') : (this.props.tooltipClicked||'Copied!')
+    var tooltip = !clicked ? (this.props.tooltip || 'Copy to clipboard') : (this.props.tooltipClicked || 'Copied!')
     el.attr('title', tooltip).tooltip('fixTitle')
-    if(el.hasClass('zeroclipboard-is-hover')) el.tooltip('show')
+    if (el.hasClass('zeroclipboard-is-hover')) el.tooltip('show')
     $(el.attr('aria-describedby')).text(tooltip)
   },
 
-  onClick: function(e) {
+  onClick: function (e) {
     e.preventDefault()
     this.setState({ clicked: true })
     this.updateTooltip(true)
 
     var t = this
-    setTimeout(function() {
+    setTimeout(function () {
       t.setState({ clicked: false })
       t.updateTooltip(false)
     }, 3000)
   },
 
-  render: function() {
+  render: function () {
     return (
-      <a href="#" className={'copier'+(this.state.clicked ? ' disabled' : '')} data-clipboard-text={this.props.copyText} onClick={this.onClick} data-toggle="tooltip" data-placement="bottom" title="Copy to clipboard">
+      <a href="#" className={'copier' + (this.state.clicked ? ' disabled' : '')}
+          data-clipboard-text={this.props.copyText} onClick={this.onClick} data-toggle="tooltip"
+          data-placement="bottom" title="Copy to clipboard">
         {this.props.children || 'Copy to clipboard'}
       </a>
     )

--- a/js/views/dhtgraph.jsx
+++ b/js/views/dhtgraph.jsx
@@ -1,26 +1,27 @@
 var React = require('react')
+var d3 = window.d3
 
 var diameter = 500,
   radius = diameter / 2,
   margin = 60,
   center = radius + margin / 2
 
-module.exports = React.createClass({
-  getInitialState: function() {
+var DHTGraph = React.createClass({
+  getInitialState: function () {
     return { initialized: false }
   },
 
-  update: function() {
+  update: function () {
     var data = this.props.peers
     var svg = this.state.svg
 
-    var outer = svg.append('circle')
+    svg.append('circle')
       .attr('r', radius)
       .attr('class', 'outer')
 
     var main = svg.append('g')
 
-    function projection(d) {
+    function projection (d) {
       var a = d.pos / 180 * Math.PI
       return [radius * Math.cos(a), radius * Math.sin(a)]
     }
@@ -33,7 +34,7 @@ module.exports = React.createClass({
       .data(data.slice(1))
       .enter().append('path')
         .attr('class', 'link')
-        .attr('d', function(d) {
+        .attr('d', function (d) {
           var start = projection(d),
             end = projection(data[0])
           return line([ start, [0, 0], end ])
@@ -44,31 +45,30 @@ module.exports = React.createClass({
       .enter().append('circle')
         .attr('class', 'node')
         .attr('r', 12)
-        .attr('transform', function(d){ return 'rotate('+d.pos+')translate('+radius+')' })
+        .attr('transform', function (d) { return 'rotate(' + d.pos + ')translate(' + radius + ')' })
 
     /*main.append('g').selectAll('text')
       .data(data)
       .enter().append('text')
         .attr('class', 'label')
-        .attr('x', function(d){ return radius * Math.cos(d.pos / 180 * Math.PI) })
-        .attr('y', function(d){ return radius * Math.sin(d.pos / 180 * Math.PI) })
+        .attr('x', function (d){ return radius * Math.cos(d.pos / 180 * Math.PI) })
+        .attr('y', function (d){ return radius * Math.sin(d.pos / 180 * Math.PI) })
         .attr('text-anchor', 'middle')
         .attr('dx', 32)
         .attr('dy', 4)
-        .text(function(d){ return d.id })*/
+        .text(function (d){ return d.id })*/
 
-
-    d3.select(self.frameElement).style('height', (diameter + margin) + 'px')
+    d3.select(window.frameElement).style('height', (diameter + margin) + 'px')
   },
 
-  componentDidMount: function() {
+  componentDidMount: function () {
     var svg = d3.select('.dht-graph').append('svg')
         .attr('width', diameter + margin)
         .attr('height', diameter + margin)
         .attr('class', 'centered')
         .style('display', 'block')
       .append('g')
-        .attr('transform', 'translate('+center+','+center+')')
+        .attr('transform', 'translate(' + center + ',' + center + ')')
 
     this.setState({
       initialized: true,
@@ -78,9 +78,10 @@ module.exports = React.createClass({
     this.update()
   },
 
-  render: function() {
-    if(this.state.initialized) this.update()
+  render: function () {
+    if (this.state.initialized) this.update()
     return <div className="dht-graph centered"></div>
   }
 })
 
+module.exports = DHTGraph

--- a/js/views/editable.jsx
+++ b/js/views/editable.jsx
@@ -1,39 +1,40 @@
 var React = require('react')
+var $ = window.$
 
-function format(value) {
+function format (value) {
   value = value.trim()
-  if(value.length > 600) value = value.substr(0, 597) + '...'
+  if (value.length > 600) value = value.substr(0, 597) + '...'
   return value
 }
 
-module.exports = React.createClass({
-  getInitialState: function() {
+var Editable = React.createClass({
+  getInitialState: function () {
     this.props.value = JSON.stringify(this.props.value).trim()
     return {}
   },
 
-  convertToInput: function(e) {
+  convertToInput: function (e) {
     var target = $(e.target)
-    if(target.hasClass('webui-editable-input')) return
+    if (target.hasClass('webui-editable-input')) return
 
     var text = this.props.value
     var input = $('<input type="text" class="form-control webui-editable-input">')
-    if(text.length > 110) input = $('<textarea class="webui-editable-input" cols="100" rows="10">')
+    if (text.length > 110) input = $('<textarea class="webui-editable-input" cols="100" rows="10">')
 
     input.val(text)
     target.replaceWith(input)
 
-    var interval = setInterval(function() {
-      if(this.convertToText({target: input})) clearInterval(interval)
+    var interval = setInterval(function () {
+      if (this.convertToText({target: input})) clearInterval(interval)
     }.bind(this), 40)
   },
 
-  convertToText: function(e) {
+  convertToText: function (e) {
     var input = $(e.target)
-    if(!input.hasClass('webui-editable-input')) return false
-    if(input.is(':active') || input.is(':hover') || input.is(':focus')) return false
+    if (!input.hasClass('webui-editable-input')) return false
+    if (input.is(':active') || input.is(':hover') || input.is(':focus')) return false
 
-    if(this.props.value !== input.val()) {
+    if (this.props.value !== input.val()) {
       this.submit(input.val())
     }
 
@@ -47,16 +48,16 @@ module.exports = React.createClass({
     return true
   },
 
-  submit: function(value) {
+  submit: function (value) {
     this.props.value = value
     console.log(value)
 
-    this.props.ipfs.config.set(this.props.key, value, function(err, res) {
+    this.props.ipfs.config.set(this.props.key, value, function (err, res) {
       console.log(err, res)
     })
   },
 
-  render: function() {
+  render: function () {
     return (
       <div>
         <div className="webui-editable" onMouseOver={this.convertToInput} onMouseOut={this.convertToText}>
@@ -66,3 +67,5 @@ module.exports = React.createClass({
     )
   }
 })
+
+module.exports = Editable

--- a/js/views/filelist.jsx
+++ b/js/views/filelist.jsx
@@ -1,32 +1,32 @@
 var React = require('react')
 var Table = require('react-bootstrap/lib/Table')
 var copier = require('./copier.jsx')
+var $ = window.$
 
-module.exports = React.createClass({
+var FileList = React.createClass({
 
-  componentDidMount: function() {
+  componentDidMount: function () {
     $(this.getDOMNode()).find('[data-toggle="tooltip"]').tooltip()
   },
 
-
-  unpin: function(e) {
+  unpin: function (e) {
     e.preventDefault()
     e.stopPropagation()
 
     var el = $(e.target)
     var hash = el.attr('data-hash')
-    if(!hash) hash = el.parent().attr('data-hash')
+    if (!hash) hash = el.parent().attr('data-hash')
 
-    this.props.ipfs.pin.remove(hash, function(err, res) {
+    this.props.ipfs.pin.remove(hash, function (err, res) {
       console.log(err, res)
     })
   },
 
-  render: function() {
+  render: function () {
     var t = this
     var files = this.props.files
-    var className = "table-hover filelist"
-    if(this.props.namesHidden) className += ' filelist-names-hidden'
+    var className = 'table-hover filelist'
+    if (this.props.namesHidden) className += ' filelist-names-hidden'
 
     return (
       <Table responsive className={className}>
@@ -39,16 +39,16 @@ module.exports = React.createClass({
           </tr>
         </thead>
         <tbody>
-        {files ? files.map(function(file) {
-          if(typeof file === 'string') file = { id: file }
+        {files ? files.map(function (file) {
+          if (typeof file === 'string') file = { id: file }
 
           var type = '?'
-          if(file.name) {
+          if (file.name) {
             var lastDot = file.name.lastIndexOf('.')
-            if(lastDot !== -1) type = file.name.substr(lastDot+1, 4).toUpperCase()
+            if (lastDot !== -1) type = file.name.substr(lastDot + 1, 4).toUpperCase()
           }
 
-          var gatewayPath = t.props.gateway+'/ipfs/'+file.id
+          var gatewayPath = t.props.gateway + '/ipfs/' + file.id
           var dagPath = '#/objects/' + file.id
           return (
             <tr className="webui-file" data-type={file.type}>
@@ -70,3 +70,5 @@ module.exports = React.createClass({
     )
   }
 })
+
+module.exports = FileList

--- a/js/views/nav.jsx
+++ b/js/views/nav.jsx
@@ -1,9 +1,9 @@
 var React = require('react')
 var Link = require('react-router').Link
 
-module.exports = React.createClass({
+var Nav = React.createClass({
 
-  render: function() {
+  render: function () {
     return (
       <div className="row">
         <ul id="side" className="nav nav-sidebar">
@@ -42,3 +42,5 @@ module.exports = React.createClass({
     )
   }
 })
+
+module.exports = Nav

--- a/js/views/nodeprops.jsx
+++ b/js/views/nodeprops.jsx
@@ -2,16 +2,18 @@ var React = require('react')
 var PropTable = require('./proptable.jsx')
 var addr = require('./typography.jsx').addr
 
-module.exports = React.createClass({
+var NodeProps = React.createClass({
 
-  render: function() {
+  render: function () {
     var node = this.props || {}
     console.log(node)
     var table = [
-      ["Node ID", addr(node.ID)],
-      ["Version", addr(node.AgentVersion)]
+      ['Node ID', addr(node.ID)],
+      ['Version', addr(node.AgentVersion)]
     ]
 
-    return PropTable({ table: table }) 
+    return PropTable({ table: table })
   }
 })
+
+module.exports = NodeProps

--- a/js/views/object.jsx
+++ b/js/views/object.jsx
@@ -1,16 +1,15 @@
 var React = require('react')
-var addr = require('./typography.jsx').addr
 
-module.exports = React.createClass({
+var ObjectView = React.createClass({
 
-  render: function() {
+  render: function () {
     var size = this.props.object.Data.length - 2
     var data = 'data:text/plain;charset=utf8;base64,' + new Buffer(this.props.object.Data.substr(0, 10000), 'utf-8').toString('base64')
 
     var back = null
     var withoutPrefix = this.props.path.replace(/^\/ip[fn]s\//, '')
     var slashIndex = withoutPrefix.indexOf('/')
-    if(slashIndex !== -1 && slashIndex !== withoutPrefix.length-1) {
+    if (slashIndex !== -1 && slashIndex !== withoutPrefix.length - 1) {
       back = (
         <div>
           <button className="btn btn-primary" onClick={this.props.handleBack}>
@@ -21,7 +20,7 @@ module.exports = React.createClass({
     }
 
     var links = <div className="padded"><span>This object has no links</span></div>
-    if(this.props.object.Links.length > 0) {
+    if (this.props.object.Links.length > 0) {
       links = (
         <div className="table-responsive">
           <table className="table table-hover filelist">
@@ -33,20 +32,23 @@ module.exports = React.createClass({
               </tr>
             </thead>
             <tbody>
-            {this.props.object.Links.map(function(link) {
+            {this.props.object.Links.map(function (link) {
               var path = window.location.hash
-              if(link.Name) path += '\\' + link.Name
-              else {
+              if (link.Name) {
+                path += '\\' + link.Name
+              } else {
                 var split = path.split('/')
-                split[split.length-1] = link.Hash
+                split[split.length - 1] = link.Hash
                 path = split.join('/')
               }
 
-              return <tr>
-                <td><a href={path} data-name={link.Name} data-hash={link.Hash}>{link.Name}</a></td>
-                <td><a href={path} data-name={link.Name} data-hash={link.Hash}>{link.Hash}</a></td>
-                <td>{link.Size}</td>
-              </tr>
+              return (
+                <tr>
+                  <td><a href={path} data-name={link.Name} data-hash={link.Hash}>{link.Name}</a></td>
+                  <td><a href={path} data-name={link.Name} data-hash={link.Hash}>{link.Hash}</a></td>
+                  <td>{link.Size}</td>
+                </tr>
+              )
             })}
             </tbody>
           </table>
@@ -54,15 +56,15 @@ module.exports = React.createClass({
       )
     }
 
-    var gatewayPath = this.props.gateway+'/ipfs/'
+    var gatewayPath = this.props.gateway + '/ipfs/'
     return (
       <div className="webui-object">
         <div className="row">
           {back}
           <h4>Links</h4>
           <div className="link-buttons">
-            <a href={gatewayPath+this.props.path} target="_blank" className="btn btn-info">RAW</a>
-            <a href={gatewayPath+this.props.path+'?dl=1'} target="_blank" className="btn btn-second">Download</a>
+            <a href={gatewayPath + this.props.path} target="_blank" className="btn btn-info">RAW</a>
+            <a href={gatewayPath + this.props.path + '?dl=1'} target="_blank" className="btn btn-second">Download</a>
             <button className="btn btn-third hidden"><i className="fa fa-lg fa-thumb-tack"></i></button>
           </div>
           <br/>
@@ -81,3 +83,5 @@ module.exports = React.createClass({
     )
   }
 })
+
+module.exports = ObjectView

--- a/js/views/page.jsx
+++ b/js/views/page.jsx
@@ -1,36 +1,39 @@
 var React = require('react')
 var Nav = require('./nav.jsx')
 var RouteHandler = require('react-router').RouteHandler
+var LocalStorage = require('../utils/localStorage')
 var Link = require('react-router').Link
+var $ = window.$
 
 var host = window.location.hostname
 var port = window.location.port || 80
-if(localStorage.daemon) {
-  host = localStorage.daemon.host
-  port = localStorage.daemon.port
+var daemonConf = LocalStorage.get('daemon')
+if (daemonConf) {
+  host = daemonConf.host
+  port = daemonConf.port
 }
 var ipfs = require('ipfs-api')(host, port)
 var ipfsHost = window.location.host
 
-module.exports = React.createClass({
-  getInitialState: function() {
+var Page = React.createClass({
+  getInitialState: function () {
     var t = this
 
-    ipfs.config.get('Addresses.Gateway', function(err, res) {
-      if(err || !res) return console.error(err)
+    ipfs.config.get('Addresses.Gateway', function (err, res) {
+      if (err || !res) return console.error(err)
 
       var split = res.Value.split('/')
       var host = split[2], port = split[4]
-      t.setState({ gateway: 'http://'+host+':'+port })
+      t.setState({ gateway: 'http://' + host + ':' + port })
     })
 
-    ipfs.version(function(err, res) {
-      if(err) return console.error(err)
+    ipfs.version(function (err, res) {
+      if (err) return console.error(err)
       t.setState({ version: res.Version })
     })
 
-    ipfs.update.check(function(err, res) {
-      if(!err && typeof res === 'object') t.setState({ updateAvailable: true })
+    ipfs.update.check(function (err, res) {
+      if (!err && typeof res === 'object') t.setState({ updateAvailable: true })
     })
 
     return {
@@ -41,27 +44,27 @@ module.exports = React.createClass({
     }
   },
 
-  showDAG: function() {
+  showDAG: function () {
     var path = $(this.getDOMNode()).find('.dag-path').val()
     window.location = '#/objects/' + path.replace(/\//g, '\\')
   },
 
-  update: function() {
+  update: function () {
     var t = this
-    ipfs.update.apply(function(err, res) {
+    ipfs.update.apply(function (err, res) {
       console.log(err, res)
       t.setState({ updating: false })
-      if(!err) window.location = window.location.toString()
+      if (!err) window.location = window.location.toString()
     })
     t.setState({ updating: true })
   },
 
-  render: function() {
+  render: function () {
     var update = null
     console.log(this.state)
-    if(this.state.updateAvailable) {
+    if (this.state.updateAvailable) {
       var updateButtonClass = 'btn btn-link'
-      if(this.state.updating) updateButtonClass += ' disabled'
+      if (this.state.updating) updateButtonClass += ' disabled'
 
       update = (
         <div className="alert alert-warning">
@@ -101,7 +104,7 @@ module.exports = React.createClass({
                               </a>
                           </li>
                           <li>
-                              <a href="#"  target="_blank" data-toggle="tooltip" data-placement="bottom" title="Documentation">
+                              <a href="#" target="_blank" data-toggle="tooltip" data-placement="bottom" title="Documentation">
                                   <img src="./static/img/info.png" alt="Documentation" className="img-responsive icon"/><span className="sr-only">Documentation</span>
                               </a>
                           </li>
@@ -123,7 +126,6 @@ module.exports = React.createClass({
       </nav>
       </div>{/* end navbar */}
 
-
       <div className="container-fluid">
         <div className="row">
 
@@ -143,3 +145,5 @@ module.exports = React.createClass({
     )
   }
 })
+
+module.exports = Page

--- a/js/views/peer.jsx
+++ b/js/views/peer.jsx
@@ -1,9 +1,9 @@
 var React = require('react')
-var addr = require('./typography.jsx').addr
+// var addr = require('./typography.jsx').addr
 var copier = require('./copier.jsx')
 
-module.exports = React.createClass({
-  render: function() {
+var Peer = React.createClass({
+  render: function () {
     return (
       <div className="webui-peer">
         <div className="box info">
@@ -35,8 +35,9 @@ module.exports = React.createClass({
 
         <h4>Network Addresses</h4>
         <div className="box addresses">
-          {(this.props.peer.Addresses || []).map(function(address) {
-            if(address) return (
+          {(this.props.peer.Addresses || []).map(function (address) {
+            if (!address) return
+            return (
               <p>
                 <code>{address}</code>&nbsp;
                 <copier copyText={address}><i className="fa fa-copy" /></copier>
@@ -48,3 +49,5 @@ module.exports = React.createClass({
     )
   }
 })
+
+module.exports = Peer

--- a/js/views/proptable.jsx
+++ b/js/views/proptable.jsx
@@ -1,13 +1,12 @@
 var React = require('react')
 var Table = require('react-bootstrap/lib/Table')
 
-module.exports = React.createClass({
-
-  render: function() {
+var PropTable = React.createClass({
+  render: function () {
     return (
       <Table responsive>
         <tbody>
-          {this.props.table.map(function(val) {
+          {this.props.table.map(function (val) {
             return (
               <tr>
                 <td className="text-left"><strong>{val[0]}</strong></td>
@@ -22,3 +21,5 @@ module.exports = React.createClass({
 
   }
 })
+
+module.exports = PropTable

--- a/js/views/swarmvis.jsx
+++ b/js/views/swarmvis.jsx
@@ -2,9 +2,8 @@ var React = require('react')
 var TabbedArea = require('react-bootstrap/lib/TabbedArea')
 var TabPane = require('react-bootstrap/lib/TabPane')
 
-module.exports = React.createClass({
-
-  render: function() {
+var Swarmvis = React.createClass({
+  render: function () {
     return (
     <div className="webui-swarm-vis">
       <TabbedArea bsStyle="pills" defaultActiveKey={1} animation={false}>
@@ -24,3 +23,5 @@ module.exports = React.createClass({
 
   }
 })
+
+module.exports = Swarmvis

--- a/js/views/table.jsx
+++ b/js/views/table.jsx
@@ -2,13 +2,12 @@ var React = require('react')
 var Table = require('react-bootstrap/lib/Table')
 var addr = require('./typography.jsx').addr
 
-module.exports = React.createClass({
-
-  render: function() {
+var Table = React.createClass({
+  render: function () {
     return (
       <Table responsive>
         <tbody>
-          {this.props.table.map(function(val) {
+          {this.props.table.map(function (val) {
             return (
               <tr><td>{addr(val)}</td></tr>
             )
@@ -20,3 +19,5 @@ module.exports = React.createClass({
 
   }
 })
+
+module.exports = Table

--- a/js/views/typography.jsx
+++ b/js/views/typography.jsx
@@ -1,7 +1,6 @@
 var React = require('react')
-var code = React.DOM.code
 
 var t = module.exports = {}
-t.addr = function(addr) {
-  return code({className: "webui-address"}, addr)
+t.addr = function (addr) {
+  return <code className="webui-address">{addr}</code>
 }

--- a/package.json
+++ b/package.json
@@ -30,14 +30,20 @@
     "gulp-uglify": "^1.1.0",
     "ipfs-node-server-static": "^1.1.2",
     "node-webkit-builder": "^1.0.11",
+    "pre-commit": "^1.0.6",
     "react-tools": "^0.13.1",
     "reactify": "^1.1.0",
+    "standard": "^3.3.2",
     "vinyl-source-stream": "^1.1.0"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "dev": "gulp"
+    "dev": "gulp",
+    "lint": "git diff --name-only --cached --relative | grep '\\.js$' | xargs standard"
   },
+  "pre-commit": [
+    "lint"
+  ],
   "author": "Juan Benet <juan@benet.ai> (http://juan.benet.ai/)",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Alright - as per our discussion, we're now complying with `standard`.

Took a while to work out all the lint errors (the fixstyle util doesn't work with jsx) but it should be smooth sailing from now on.

Just a note on the module.exports syntax, React can automatically figure out via JSX what the displayName is if you use `var Foo = React.createClass({})`, but it appears it can't do it if you do `var Foo = module.exports = React.createClass({})`, thus the changes. It's really nice to have the displayName for debugging.