### PR TITLE
Fixes #31, allowing unpinning via the webui

### DIFF
--- a/js/pages/files.jsx
+++ b/js/pages/files.jsx
@@ -12,12 +12,12 @@ var Files = React.createClass({
     function getFiles () {
       t.props.ipfs.pin.list(function (err, pinned) {
         if (err || !pinned) return t.error(err)
-        t.setState({ pinned: pinned.Keys.sort() })
+        t.setState({ pinned: Object.keys(pinned.Keys).sort() })
       })
 
       t.props.ipfs.pin.list('recursive', function (err, pinned) {
         if (err || !pinned) return t.error(err)
-        t.setState({ local: pinned.Keys.sort() })
+        t.setState({ local: Object.keys(pinned.Keys).sort() })
       })
     }
 

--- a/js/views/filelist.jsx
+++ b/js/views/filelist.jsx
@@ -18,7 +18,7 @@ var FileList = React.createClass({
     var hash = el.attr('data-hash')
     if (!hash) hash = el.parent().attr('data-hash')
 
-    this.props.ipfs.pin.remove(hash, function (err, res) {
+    this.props.ipfs.pin.remove(hash, {r: true}, function (err, res) {
       console.log(err, res)
     })
   },

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "debug": "^2.1.3",
     "font-awesome": "^4.3.0",
     "font-awesome-webpack": "0.0.3",
-    "ipfs-api": "^1.1.0",
+    "ipfs-api": "^1.2.0",
     "jquery": "^2.1.3",
     "lodash": "^3.6.0",
     "react": "^0.13.1",


### PR DESCRIPTION
There are few fixes in this, mostly though this is to allow users to
unpin from the webui. This commit includes a version bump of the
`node-ipfs-api`, as well as passing in the recursive flag.

An unexpected addition to this commit is due to a change in `go-ipfs`
passing back an object of keys instead of an array.