### PR TITLE
metrics: pretty ugly d3 plotting

### DIFF
--- a/js/app.jsx
+++ b/js/app.jsx
@@ -13,6 +13,7 @@ var BitswapPage = require('./pages/bitswap.jsx')
 var RoutingPage = require('./pages/routing.jsx')
 var ConfigPage = require('./pages/config.jsx')
 var LogPage = require('./pages/logs.jsx')
+var MetricsPage = require('./pages/metrics.jsx');
 var NotFoundPage = require('./pages/notfound.jsx')
 
 module.exports = (
@@ -30,6 +31,7 @@ module.exports = (
     <Route name="routing" handler={RoutingPage} />
     <Route name="config" handler={ConfigPage} />
     <Route name="logs" handler={LogPage} />
+    <Route name="metrics" handler={MetricsPage} />
     <NotFoundRoute handler={NotFoundPage} />
     <Redirect from="/index.html" to="home" />
   </Route>

--- a/js/pages/metrics.jsx
+++ b/js/pages/metrics.jsx
@@ -1,0 +1,136 @@
+var React = require('react');
+var $ = require('jquery');
+var LineChart = require('react-d3').LineChart;
+
+
+var Metrics = React.createClass({
+  getInitialState: function () {
+    var t = this;
+
+    var zero =  { x: 0, y: 0 };
+    var generalData = [
+      {name:"Alloc", values: [zero]   }, // react-d3 somehow dislikes empty values
+      // {name:"TotalAlloc", values: [zero] },
+      {name:"Sys", values: [zero] },
+    ];
+
+    var accessData = [
+      {name:"Lookups", values: [zero] },
+      {name:"Mallocs", values: [zero] },
+      {name:"Frees", values: [zero] },
+    ]
+
+    var heapData = [
+      {name:"HeapAlloc", values: [zero]   }, // react-d3 somehow dislikes empty values
+      // {name:"TotalAlloc", values: [zero] },
+      {name:"HeapSys", values: [zero] },
+      {name:"HeapIdle", values: [zero] },
+      {name:"HeapInuse", values: [zero] },
+    ];
+
+    var stackData = [
+      {name:"StackInuse", values: [ zero ]   }, // react-d3 somehow dislikes empty values
+      {name:"StackSys", values: [zero] },
+
+    {name:"StackInuse" , values:[zero]},
+   {name:"StackSys"   , values:[zero]},
+   {name:"MSpanInuse" , values:[zero]},
+   {name:"MSpanSys"   , values:[zero]},
+   {name:"MCacheInuse", values:[zero]},
+   {name:"MCacheSys"  , values:[zero]},
+   {name:"BuckHashSys", values:[zero]},
+   {name:"GCSys"      , values:[zero]},
+   {name:"OtherSys"   , values:[zero]},
+    ];
+
+    var getData = function() {
+      var xhr = $.get("http://localhost:8010/debug/vars");
+      xhr.done(function(resp) {
+        // console.log("xhr succeeded");
+
+        generalData.forEach(function(elem, idx) {
+          elem.values.push({x:elem.values.length, y:resp.memstats[elem.name]});
+        });
+
+        accessData.forEach(function(elem, idx) {
+          elem.values.push({x:elem.values.length, y:resp.memstats[elem.name]});
+        });
+
+        heapData.forEach(function(elem, idx) {
+          elem.values.push({x:elem.values.length, y:resp.memstats[elem.name]});
+        });
+
+        stackData.forEach(function(elem, idx) {
+          elem.values.push({x:elem.values.length, y:resp.memstats[elem.name]});
+        });
+
+        t.setState({
+          generalData: generalData,
+          accessData: accessData,
+          heapData: heapData,
+          stackData: stackData,
+        });
+
+      });
+      xhr.fail(function(err) {
+        console.error(arguments);
+        t.error(err);
+      });
+    };
+
+    getData();
+    // setting the inverval to low results in:
+    // Uncaught Error: Invariant Violation: setState(...): Cannot update during an existing state transition (such as within `render`). Render methods should be a pure function of props and state.
+    t.pollInterval = setInterval(getData, 5000);
+
+    return {
+      generalData: generalData,
+      accessData: accessData,
+      heapData: heapData,
+      stackData: stackData,
+    };
+  },
+
+  componentWillUnmount: function () {
+    clearInterval(this.pollInterval);
+  },
+
+
+  render: function () {
+    return (
+      <div className="row">
+        <div className="col-sm-10 col-sm-offset-1 webui-logs">
+          <h2>Garbage collector statistics</h2>
+          <p>See the <a target="_blank" href="https://godoc.org/pkg/runtime#MemStats">godocs</a> for more.</p>
+          <LineChart
+            data={this.state.generalData}
+            legend={true} width={700} height={300}
+            title="General Stats"
+          />
+
+          <LineChart
+            data={this.state.accessData}
+            legend={true} width={700} height={300}
+            title="access Stats"
+          />
+
+          <LineChart
+            data={this.state.heapData}
+            legend={true} width={700} height={300}
+            title="Heap Stats"
+          />
+
+          <LineChart
+            data={this.state.stackData}
+            legend={true} width={700} height={300}
+            title="Stack Stats"
+          />
+        </div>
+      </div>
+  );
+}
+});
+
+
+
+module.exports = Metrics;

--- a/js/pages/metrics.jsx
+++ b/js/pages/metrics.jsx
@@ -7,7 +7,7 @@ var Metrics = React.createClass({
   getInitialState: function () {
     var t = this;
 
-    var zero =  { x: 0, y: 0 };
+    var zero =  { x: new Date(), y: 0 };
     var generalData = [
       {name:"Alloc", values: [zero]   }, // react-d3 somehow dislikes empty values
       // {name:"TotalAlloc", values: [zero] },
@@ -49,19 +49,19 @@ var Metrics = React.createClass({
         // console.log("xhr succeeded");
 
         generalData.forEach(function(elem, idx) {
-          elem.values.push({x:elem.values.length, y:resp.memstats[elem.name]});
+          elem.values.push({x:new Date(), y:resp.memstats[elem.name]});
         });
 
         accessData.forEach(function(elem, idx) {
-          elem.values.push({x:elem.values.length, y:resp.memstats[elem.name]});
+          elem.values.push({x:new Date(), y:resp.memstats[elem.name]});
         });
 
         heapData.forEach(function(elem, idx) {
-          elem.values.push({x:elem.values.length, y:resp.memstats[elem.name]});
+          elem.values.push({x:new Date(), y:resp.memstats[elem.name]});
         });
 
         stackData.forEach(function(elem, idx) {
-          elem.values.push({x:elem.values.length, y:resp.memstats[elem.name]});
+          elem.values.push({x:new Date(), y:resp.memstats[elem.name]});
         });
 
         t.setState({

--- a/js/views/nav.jsx
+++ b/js/views/nav.jsx
@@ -37,6 +37,11 @@ var Nav = React.createClass({
               <span className="icon fa fa-list" aria-hidden="true"></span> Logs
             </Link>
           </li>
+          <li>
+            <Link className="link" to="metrics">
+              <span className="icon fa fa-list" aria-hidden="true"></span> Metrics
+            </Link>
+          </li>
         </ul>
       </div>
     )

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "react": "^0.13.1",
     "react-async": "^2.1.0",
     "react-bootstrap": "^0.20.1",
+    "react-d3": "^0.3.1",
     "react-localstorage": "^0.2.2",
     "react-router": "^0.13.2",
     "three": "^0.66.0",


### PR DESCRIPTION
![](http://www.orangedonkey.net/wp-content/uploads/2012/04/I-Have-No-Idea-What-I-am-Doing-5.jpg)

bare with me, my d3 and react isn't very good.. ipfs/go-ipfs#1163 adds an API endpoint on port 5001 that exposes metrics about the memory consumption of the daemon (`memstats`) and custom metrics about the datastores. ([here](https://gist.githubusercontent.com/cryptix/be8bccb4f0aa414c906c/raw/328354518b1c1b959b6f9d3bf0ab4710a9e0512b/gistfile1.json) is a sample of the JSON)

I like to visualize those, after some googling I stubmled over some handwoven d3 react magic and finally 
[react-d3](https://www.npmjs.com/package/react-d3).

Currently it looks like this:

![stats](https://cloud.githubusercontent.com/assets/111202/7403949/3b212e0a-eedc-11e4-96b8-b44a27dffdf8.png)

but after some time the plots stop to update and I get this in the console:

```
Uncaught Error: Invariant Violation: setState(...): Cannot update during an existing state transition (such as within `render`). Render methods should be a pure function of props and state.
```

Like I said, my reactjs knowledge isn't very good (this might be my first public commit) and I wanted some feedback (and maybe a better plotting lib suggestion?) on the general approach before I sink more time into this.

Obvious TODOS:

- [x] time on the x axis
- [ ] formatting the Y axis properly
- [ ] hiding data lines by clicking the legends?
- [ ] the custom metrics also have histogram data in percentiles. Might want another chart type for that.

ps: I needed to add `/debug/` to [ipfs-node-server-static](https://github.com/travisperson/ipfs-node-server-static/blob/master/index.js#L54) so that the requests are proxied properly.