### PR TITLE
Remove polling interval from files view

### DIFF
--- a/js/pages/files.jsx
+++ b/js/pages/files.jsx
@@ -27,7 +27,6 @@ var Files = React.createClass({
     }
 
     getFiles()
-    t.pollInterval = setInterval(getFiles, 1000)
 
     return {
       files: files,


### PR DESCRIPTION
This made the files page go from eating 100% cpu to idle.

I'd argue the relevant time you want to update these listings, is while adding files through the webui, and as this case is already covered without polling, i think we should just drop this line.

Cannot think of any usecase where you would want to have polling updates of pinned files at this point.

Maybe it does not fix #20 in its entirety, but it makes a huge difference in performance.