### PR TITLE
stop navbar flowing into to two lines

### DIFF
--- a/less/bundle.less
+++ b/less/bundle.less
@@ -37,7 +37,7 @@ p {
 
   > .form-group {
     > input {
-      width: 460px;
+      width: 350px;
       background-color: #555;
       color: #ddd;
       border: #aaa;


### PR DESCRIPTION
![navbar-fail](https://cloud.githubusercontent.com/assets/59379/8001749/ed44d124-0b68-11e5-97d1-43e2ce799a8b.png)

Would still probably be better to keep the path at a flexbox-style maximum middle width. But this is better for now.