### PR TITLE
Bypass CORS in development by proxying `Origin` headers correctly

### DIFF
--- a/byggfile.js
+++ b/byggfile.js
@@ -11,12 +11,17 @@ var rename = require('bygg-plugins-light/rename')
 var proxy = require('proxy-middleware')
 var url = require('url')
 
+var HOST = 'http://localhost:5001'
+
 bygg.task('serve', function () {
   return build()
     .pipe(bygg.write('build/'))
     .pipe(serve(3000, function (app) {
-      var opts = url.parse('http://localhost:5001/api')
-      opts.headers = {'referer': 'http://localhost:5001/'}
+      var opts = url.parse(HOST + '/api')
+      opts.headers = {
+        referer: HOST + '/',
+        origin: HOST
+      }
       return app
         .use('/api', proxy(opts))
     }))


### PR DESCRIPTION
#### :tophat: What? Why?

`go-ipfs` does some kind of poor man's CORS by checking the `Origin` header.
Current web-ui dev build adds correctly `referer` header but not the origin one.

#### How to test

Adding files in development shouldn't return `403` anymore.

#### :ghost: GIF
![](https://media.giphy.com/media/11OOAQSnUaZT2M/giphy.gif)