### PR TITLE
swap params in _unpin method

### DIFF
--- a/src/app/js/views/filelist.js
+++ b/src/app/js/views/filelist.js
@@ -44,7 +44,7 @@ class FileList extends Component {
                     <span className='separator'>|</span>
                     <a href={dagPath}>{i18n.t('DAG')}</a>
                     <span className='separator'>|</span>
-                    <a href='#' onClick={(event) => this._unpin(event, file.id)}>
+                    <a href='#' onClick={(event) => this._unpin(file.id, event)}>
                       <OverlayTrigger placement='right' overlay={<Tooltip id={file.id}>{i18n.t('Remove')}</Tooltip>}>
                         <i className='fa fa-remove' />
                       </OverlayTrigger>


### PR DESCRIPTION
the _unpin method expects params (hash, event). Calling the method with  this._unpin(event, file.id) will cause an error.