### PR TITLE
Make the API accessible from the default HTTPS port

### DIFF
--- a/src/app/js/components/ipfs.js
+++ b/src/app/js/components/ipfs.js
@@ -3,7 +3,7 @@ import {toastr} from 'react-redux-toastr'
 import createReactClass from 'create-react-class'
 
 const host = (process.env.NODE_ENV !== 'production') ? 'localhost' : window.location.hostname
-const port = (process.env.NODE_ENV !== 'production') ? '5001' : (window.location.port || 80)
+const port = (process.env.NODE_ENV !== 'production') ? '5001' : (window.location.port || (window.location.protocol === 'https:' ? 443 : 80))
 const ipfs = require('ipfs-api')(host, port)
 
 let version = ''

--- a/src/app/js/services/api.js
+++ b/src/app/js/services/api.js
@@ -4,7 +4,7 @@ import {join} from 'path'
 import bl from 'bl'
 
 const host = (process.env.NODE_ENV !== 'production') ? 'localhost' : window.location.hostname
-const port = (process.env.NODE_ENV !== 'production') ? '5001' : (window.location.port || 80)
+const port = (process.env.NODE_ENV !== 'production') ? '5001' : (window.location.port || (window.location.protocol === 'https:' ? 443 : 80))
 const localApi = new API(host, port)
 
 function collect (stream) {


### PR DESCRIPTION
Fixes an issue mentioned in a comment for #95:
> There's also problems if you're trying to put HTTPS in front of the UI via nginx. It loads fine, but then the web-ui immediately tries to access it's own content via HTTP rather then HTTPS and is blocked.